### PR TITLE
:package: Set python_requires mode to major_mode

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -42,6 +42,7 @@ class libhal_mac_conan(ConanFile):
         self.cpp_info.libs = ["libhal-mac"]
 
     def package_id(self):
+        self.info.python_requires.major_mode()
         if self.info.options.get_safe("platform"):
             del self.info.options.platform
         self.buildenv_info.define("LIBHAL_PLATFORM", "mac")


### PR DESCRIPTION
By setting the mode for `python_requires` to `major_mode` only the major_mode

will represent a breaking change between new versions of `libhal-bootstrap`.